### PR TITLE
added implementation of new fetching journeys (without errors now)

### DIFF
--- a/src/app/api/v1/bahnhof-proxy/route.ts
+++ b/src/app/api/v1/bahnhof-proxy/route.ts
@@ -48,6 +48,7 @@ const mapConnection = (entry: any): Connection => {
     return {
         ris_journeyId: entry.journeyID,
         destination: mapStops(entry.destination)[0],
+        actualDestination: entry.actualDestination ? mapStops(entry.actualDestination)[0] : undefined,
         departure: {
             plannedTime: entry.timeSchedule,
             actualTime: entry.timeDelayed,

--- a/src/app/api/v1/bahnhof-proxy/route.ts
+++ b/src/app/api/v1/bahnhof-proxy/route.ts
@@ -47,11 +47,7 @@ const mapConnection = (entry: any): Connection => {
 
     return {
         ris_journeyId: entry.journeyID,
-        destination: {
-            id: entry.destination.evaNumber,
-            name: entry.destination.name,
-            cancelled: entry.destination.cancelled
-        },
+        destination: mapStops(entry.destination)[0],
         departure: {
             plannedTime: entry.timeSchedule,
             actualTime: entry.timeDelayed,
@@ -64,10 +60,10 @@ const mapConnection = (entry: any): Connection => {
             additionalLineName: entry.additionalLineName,
             fullName: entry.lineName,
         },
-        viaStops: entry.viaStops,
-        canceledStopsAfterActualDestination: entry.canceledStopsAfterActualDestination,
-        additionalStops: entry.additionalStops,
-        canceledStops: entry.canceledStops,
+        viaStops: mapStops(entry.viaStops),
+        canceledStopsAfterActualDestination: mapStops(entry.canceledStopsAfterActualDestination),
+        additionalStops: mapStops(entry.additionalStops),
+        canceledStops: mapStops(entry.canceledStops),
         messages: entry.messages,
         cancelled: entry.canceled,
     }

--- a/src/app/api/v1/station/departures/route.ts
+++ b/src/app/api/v1/station/departures/route.ts
@@ -37,6 +37,7 @@ const vendoDB = async (id: string, when: string, duration: number, results: numb
 
         const connection: Connection = {
             ris_journeyId: departure.tripId,
+            direction: departure.direction,
             destination: {
                 id: departure.destination.id,
                 name: departure.destination.name
@@ -80,6 +81,7 @@ const vendoDBNav = async (id: string, when: string, duration: number, results: n
 
         const connection: Connection = {
             hafas_journeyId: departure.tripId,
+            direction: departure.direction,
             departure: {
                 plannedTime: departure.plannedWhen,
                 actualTime: departure.when,                     // nullable

--- a/src/app/lib/mapper.ts
+++ b/src/app/lib/mapper.ts
@@ -1,12 +1,34 @@
 import {Connection, Journey} from "@/app/lib/objects";
 
+const normalize = (name?: string): string | undefined => {
+    return name?.replace(/\s+/g, '').toLowerCase();
+}
+
 const mapConnections = (journeys: Journey[], connections: Connection[]): { journeys: Journey[], faulty: Connection[] } => {
     const matched = new Set<string>();
 
     const updatedJourneys = journeys.map((journey: Journey) => ({
         ...journey,
         connections: journey.connections.map((connection: Connection) => {
-            const matching = connections.find((conn: Connection) => conn.ris_journeyId === connection.ris_journeyId);
+            // connection   - from RIS
+            // conn         - from HAFAS
+            const matching = connections.find((conn: Connection) => {
+                if (connection.hafas_journeyId && (connection.hafas_journeyId === conn.hafas_journeyId)) return true;
+
+                const connectionFullName = normalize(connection.lineInformation?.fullName);
+                const connFullName = normalize(conn.lineInformation?.fullName);
+
+                const platformMatch = connection.departure?.plannedPlatform && conn.departure?.plannedPlatform
+                    ? connection.departure?.plannedPlatform === conn.departure?.plannedPlatform
+                    : true;
+
+                return (
+                    platformMatch &&
+                    connection.departure?.plannedTime === conn.departure?.plannedTime &&
+                    (connectionFullName === connFullName || connFullName?.includes(connectionFullName ?? '') || connectionFullName?.includes(connFullName ?? '')) &&
+                    connection.destination?.name === conn.direction
+                );
+            });
             if (!matching) return connection;
 
             if (matching.ris_journeyId) matched.add(matching.ris_journeyId);
@@ -15,11 +37,6 @@ const mapConnections = (journeys: Journey[], connections: Connection[]): { journ
             return {
                 ...connection,
                 ...matching,
-                lineInformation: {
-                    ...connection.lineInformation,
-                    ...matching.lineInformation,
-                    kind: connection.lineInformation?.kind ?? matching.lineInformation?.kind
-                }
             };
         })
     }));

--- a/src/app/lib/objects.ts
+++ b/src/app/lib/objects.ts
@@ -2,18 +2,11 @@ export type Connection = {
     ris_journeyId?: string,          // RIS identifier   (DB RIS internal, HAFAS v2)
     hafas_journeyId?: string,        // HAFAS identifier (HAFAS v1)
     tripId?: string,
-    origin?: {
-        id: string,
-        name: string,
-        cancelled?: boolean,
-    },
-    destination?: {
-        id: string,
-        name: string,
-        cancelled?: boolean
-    },
-    ueber?: string[],               // the stops where the train stops
-    viaStops?: string[],               // the stops where the train stops
+    origin?: Stop,
+    destination?: Stop,
+    walking?: boolean,
+    direction?: string,
+    viaStops?: Stop[],                  // the stops where the train stops
     departure?: {
         plannedTime: string,        // the time when the train should have departed
         actualTime: string,         // the time when the train actually departed
@@ -44,14 +37,28 @@ export type Connection = {
         latitude: number,
         longitude: number
     },
-    canceledStopsAfterActualDestination?: any[],
-    additionalStops?: any[],
-    canceledStops?: any[],
+    canceledStopsAfterActualDestination?: Stop[],
+    additionalStops?: Stop[],
+    canceledStops?: Stop[],
     stopovers?: [],
     remarks?: [],
     messages?: any,
     cancelled?: boolean,
     loadFactor?: string
+}
+
+export type Stop = {
+    id: string,
+    name: string,
+    cancelled: boolean,
+    additional?: boolean,
+    separation?: boolean,
+    nameParts?: NamePart[]
+}
+
+export type NamePart = {
+    type: string,
+    value: string
 }
 
 // a journey can hold multiple connections, e.g. if the train parts are separated later

--- a/src/app/lib/objects.ts
+++ b/src/app/lib/objects.ts
@@ -4,6 +4,7 @@ export type Connection = {
     tripId?: string,
     origin?: Stop,
     destination?: Stop,
+    actualDestination?: Stop,
     walking?: boolean,
     direction?: string,
     viaStops?: Stop[],                  // the stops where the train stops

--- a/src/app/lib/utils.ts
+++ b/src/app/lib/utils.ts
@@ -1,0 +1,28 @@
+import {Stop} from "@/app/lib/objects";
+
+const browserLanguage = (): string => {
+    const supported = ['en', 'de'];
+    const language = navigator.language.split("-")[0];
+    return supported.includes(language) ? language : 'en';
+}
+
+const mapStops = (rawData: any): Stop[] => {
+    if (!Array.isArray(rawData)) rawData = [rawData];
+
+    return rawData.map((rawStop: any) => {
+        const {evaNumber, name, canceled, additional, separation, nameParts} = rawStop;
+        return {
+            id: evaNumber,
+            name: name,
+            cancelled: canceled,
+            additional: additional || false,
+            separation: separation || false,
+            nameParts: nameParts ? nameParts.map((part: any) => ({
+                type: part.type,
+                value: part.value
+            })) : [{type: "default", value: name}]
+        };
+    });
+}
+
+export {browserLanguage, mapStops};


### PR DESCRIPTION
This PR addresses the challenges of mapping connections (see #9) between the Bahnhof API (using UUIDv4 RIS ids) and the [dbnav profile](https://github.com/public-transport/db-vendo-client/blob/41feb41b5a53afa554b300d5f06348c8c1d5128e/readme.md?plain=1#L25) (using HAFAS ids). The following improvements have been implemented to streamline the mapping process and resolve mismatches.

**Optimized HAFAS id lookup:**
If a connection already has a HAFAS id, the mapping logic immediately checks for this ID, bypassing unnecessary computations in the `find` method. This reduces overhead and improves performance. See [here](https://github.com/schmolldechse/navigator/blob/773f76425e33755d9e5647f05291df1b29a9b513/src/app/lib/mapper.ts#L16).

**Handling missing departure platforms:**
For cases where a connection lacks a departure/ arrival platform (e.g. bus connections), the platform matching condition defaults to `true`. This ensures that such connections are not excluded from mapping due to missing data. See [here](https://github.com/schmolldechse/navigator/blob/773f76425e33755d9e5647f05291df1b29a9b513/src/app/lib/mapper.ts#L21).