### PR TITLE
Add loading spinner

### DIFF
--- a/frontend/src/components/Loader.svelte
+++ b/frontend/src/components/Loader.svelte
@@ -1,0 +1,72 @@
+<span class="loader"></span>
+
+<style>
+	/* https://cssloaders.github.io/ */
+	.loader {
+		animation: rotate 1s infinite;
+		height: 50px;
+		width: 50px;
+	}
+
+	.loader:before,
+	.loader:after {
+		border-radius: 50%;
+		content: "";
+		display: block;
+		height: 20px;
+		width: 20px;
+	}
+	.loader:before {
+		animation: ball1 1s infinite;
+		background-color: var(--text);
+		box-shadow: 30px 0 0 var(--accent);
+		margin-bottom: 10px;
+	}
+	.loader:after {
+		animation: ball2 1s infinite;
+		background-color: var(--accent);
+		box-shadow: 30px 0 0 var(--text);
+	}
+
+	@keyframes rotate {
+		0% {
+			transform: rotate(0deg) scale(0.8);
+		}
+		50% {
+			transform: rotate(360deg) scale(1.2);
+		}
+		100% {
+			transform: rotate(720deg) scale(0.8);
+		}
+	}
+
+	@keyframes ball1 {
+		0% {
+			box-shadow: 30px 0 0 var(--accent);
+		}
+		50% {
+			box-shadow: 0 0 0 var(--accent);
+			margin-bottom: 0;
+			transform: translate(15px, 15px);
+		}
+		100% {
+			box-shadow: 30px 0 0 var(--accent);
+			margin-bottom: 10px;
+		}
+	}
+
+	@keyframes ball2 {
+		0% {
+			box-shadow: 30px 0 0 var(--text);
+		}
+		50% {
+			box-shadow: 0 0 0 var(--text);
+			margin-top: -20px;
+			transform: translate(15px, 15px);
+		}
+		100% {
+			box-shadow: 30px 0 0 var(--text);
+			margin-top: 0;
+		}
+	}
+</style>

--- a/frontend/src/routes/(root)/[evaNumber=int]/[type=type]/+page.server.ts
+++ b/frontend/src/routes/(root)/[evaNumber=int]/[type=type]/+page.server.ts
@@ -4,8 +4,8 @@ import type { Journey } from "$models/connection";
 import { DateTime } from "luxon";
 import { env } from "$env/dynamic/private";
 
-export const load: PageServerLoad = async ({ params, url }): Promise<{ journeys: Journey[] }> => {
-	const journeys = await loadJourneys(
+export const load: PageServerLoad = async ({ params, url }): Promise<{ journeys: Promise<Journey[]> }> => {
+	const journeys = loadJourneys(
 		params.evaNumber,
 		params.type,
 		url.searchParams.get("startDate") ?? DateTime.now().set({ second: 0, millisecond: 0 }).toISO()

--- a/frontend/src/routes/(root)/[evaNumber=int]/[type=type]/+page.svelte
+++ b/frontend/src/routes/(root)/[evaNumber=int]/[type=type]/+page.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
+	import { onMount } from "svelte";
 	import type { PageProps } from "./$types";
 	import Filter from "$components/timetable/filter/Filter.svelte";
 	import type { Connection, Journey } from "$models/connection";
 	import ConnectionComponent from "$components/timetable/ConnectionComponent.svelte";
 	import WingTrain from "$components/timetable/WingTrain.svelte";
+	import Loader from "$components/Loader.svelte";
 
 	let { data }: PageProps = $props();
 
 	let currentFilter = $state(["*"]);
+
 	const matchesFilter = (journey: Journey) => {
 		if (currentFilter.length === 0) return true;
 		if (currentFilter.includes("*")) return true;
@@ -18,26 +21,33 @@
 		return currentFilter.includes(firstConnection?.lineInformation?.type ?? "");
 	};
 
-	const allowedProducts = (): string[] => {
-		const products = data?.station?.products || [];
+	const allowedProducts = (journeys: Journey[] | undefined): string[] => {
+		const products = data.station?.products || [];
 
-		const types = data?.journeys
-			?.flatMap((journey) => journey.connections.map((conn) => conn.lineInformation?.type))
+		const types = journeys!
+			.flatMap((journey) => journey.connections.map((conn) => conn.lineInformation?.type))
 			.filter(Boolean);
+
 		return products.filter((product) => types.includes(product));
 	};
 </script>
 
-<div class="scrollbar-track-sky-300 container mx-auto flex flex-1 flex-col divide-y-2 md:divide-y-0">
-	{#each data.journeys as journey}
-		{#if !matchesFilter(journey)}{:else if journey.connections.length > 1}
-			<WingTrain {journey} />
-		{:else}
-			<ConnectionComponent connection={journey.connections[0]} renderInformation={true} renderBorder={true} />
-		{/if}
-	{/each}
-</div>
+{#await data.journeys}
+	<div class="mx-auto flex-1">
+		<Loader />
+	</div>
+{:then journeys}
+	<div class="scrollbar-track-sky-300 container mx-auto flex flex-1 flex-col divide-y-2 md:divide-y-0">
+		{#each journeys as journey}
+			{#if !matchesFilter(journey)}{:else if journey.connections.length > 1}
+				<WingTrain {journey} />
+			{:else}
+				<ConnectionComponent connection={journey.connections[0]} renderInformation={true} renderBorder={true} />
+			{/if}
+		{/each}
+	</div>
 
-<div class="sticky bottom-0 mt-auto w-full">
-	<Filter allowedProducts={allowedProducts()} bind:selected={currentFilter} />
-</div>
+	<div class="sticky bottom-0 mt-auto w-full">
+		<Filter allowedProducts={allowedProducts(journeys)} bind:selected={currentFilter} />
+	</div>
+{/await}


### PR DESCRIPTION
This pull request adds a loading spinner to the journeys page. To accomplish this the following changes were made:

**New Loading Spinner:**
* [`frontend/src/components/Loader.svelte`](diffhunk://#diff-479b64409aab8f424d205dc36fe7330f7f0c0ca21afd165abd9381e1813726aeR1-R72): Added a new loading spinner component with CSS animations for visual feedback during data loading.

**Journey Loading Process:**
* `frontend/src/routes/(root)/[evaNumber=int]/[type=type]/+page.server.ts`: Modified the `load` function to return a `Promise` of journeys instead of awaiting the result immediately. ([frontend/src/routes/(root)/[evaNumber=int]/[type=type]/+page.server.tsL7-R8](diffhunk://#diff-23795263ef14b63a7137ba3091bdef2bfef913369717863bb8ce511306b9dc86L7-R8))
* `frontend/src/routes/(root)/[evaNumber=int]/[type=type]/+page.svelte`: Integrated the new `Loader` component to display a loading spinner while awaiting journey data. ([frontend/src/routes/(root)/[evaNumber=int]/[type=type]/+page.svelteR2-R13](diffhunk://#diff-b6cfd9794e01aa95cb1efc95ffcd5e03866d01ad61feccd4f1ff1d37e78c78d5R2-R13), [frontend/src/routes/(root)/[evaNumber=int]/[type=type]/+page.svelteL21-R41](diffhunk://#diff-b6cfd9794e01aa95cb1efc95ffcd5e03866d01ad61feccd4f1ff1d37e78c78d5L21-R41), [frontend/src/routes/(root)/[evaNumber=int]/[type=type]/+page.svelteL42-R53](diffhunk://#diff-b6cfd9794e01aa95cb1efc95ffcd5e03866d01ad61feccd4f1ff1d37e78c78d5L42-R53))