### PR TITLE
fix(backend): schema path

### DIFF
--- a/backend/drizzle.config.ts
+++ b/backend/drizzle.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({
 	out: "./drizzle",
-	schema: ["./src/db/*.ts"],
+	schema: ["./src/db/postgres/*.ts"],
 	schemaFilter: ["auth", "data"],
 	dialect: "postgresql",
 	dbCredentials: {


### PR DESCRIPTION
This pull request includes a small but important change to the backend/drizzle.config.ts file. The modification corrects the schema path, ensuring it now accurately points to the PostgreSQL schema files.

- [backend/drizzle.config.ts](https://www.perplexity.ai/search/this-pull-request-includes-a-s-LRZWHF5iQlC.nKarmnUrug): Corrected the schema path to ./src/db/postgres/*.ts, which now properly references the location of our PostgreSQL schema files.