### PR TITLE
Add message tooltips

### DIFF
--- a/frontend/src/components/timetable/messages/Messages.svelte
+++ b/frontend/src/components/timetable/messages/Messages.svelte
@@ -105,7 +105,9 @@
 			{@const validMessage = validMessages.find((validMessage) => validMessage.type === message.type)}
 			{#if validMessage?.component}
 				{@const Component = validMessage.component}
-				<Component />
+				<div title={formatMessage(message)}>
+					<Component />
+				</div>
 			{/if}
 		{/each}
 		<ShowMore onclick={() => (expanded = true)} />


### PR DESCRIPTION
This pull request includes a small change to the `frontend/src/components/timetable/messages/Messages.svelte` file. The change wraps the message component in a `div` with a `title` attribute that uses the `formatMessage` function to display the message content as a tooltip.

* [`frontend/src/components/timetable/messages/Messages.svelte`](diffhunk://#diff-750ec02279166ccd16c115572aaa1bcb9666a2eb7f20f3ea11347de1aa9335b5R108-R110): Wrapped the message component in a `div` with a `title` attribute to display the formatted message as a tooltip.