### PR TITLE
feat: improvements to route planner & bugfixes

### DIFF
--- a/backend/src/lib/merge.ts
+++ b/backend/src/lib/merge.ts
@@ -36,10 +36,10 @@ const merge = (connectionA: Connection, connectionB: Connection, type: RequestTy
 			}
 		},
 		viaStops: connectionA?.viaStops ?? connectionB?.viaStops ?? undefined,
-		cancelledStopsAfterActualDestination:
-			connectionA?.cancelledStopsAfterActualDestination ?? connectionB?.cancelledStopsAfterActualDestination ?? undefined,
-		additionalStops: connectionA?.additionalStops ?? connectionB?.additionalStops ?? undefined,
-		cancelledStops: connectionA?.cancelledStops ?? connectionB?.cancelledStops ?? undefined,
+		// cancelledStopsAfterActualDestination:
+		// 	connectionA?.cancelledStopsAfterActualDestination ?? connectionB?.cancelledStopsAfterActualDestination ?? undefined,
+		// additionalStops: connectionA?.additionalStops ?? connectionB?.additionalStops ?? undefined,
+		// cancelledStops: connectionA?.cancelledStops ?? connectionB?.cancelledStops ?? undefined,
 		messages: connectionA?.messages ?? connectionB?.messages ?? undefined,
 		cancelled: connectionA?.cancelled ?? connectionB?.cancelled ?? false,
 		providesVehicleSequence: connectionA?.providesVehicleSequence ?? connectionB?.providesVehicleSequence ?? false
@@ -47,9 +47,7 @@ const merge = (connectionA: Connection, connectionB: Connection, type: RequestTy
 };
 
 const mergeConnections = (
-	// connections from `db` profile
 	connectionsA: Connection[],
-	// connections from `dbweb` profile
 	connectionsB: Connection[],
 	type: RequestType,
 	destinationOriginCriteria: boolean = false

--- a/backend/src/lib/time.ts
+++ b/backend/src/lib/time.ts
@@ -5,9 +5,7 @@ const calculateDuration = (
 	endDate: DateTime,
 	unit: "milliseconds" | "seconds" | "minutes" | "hours" | "days"
 ): number => {
-	if (!startDate.isValid || !endDate.isValid) {
-		throw new Error("Invalid DateTime objects provided");
-	}
+	if (!startDate.isValid || !endDate.isValid) return -1;
 	return startDate.diff(endDate).as(unit);
 };
 

--- a/frontend/src/components/route-planner/RouteRequest.svelte
+++ b/frontend/src/components/route-planner/RouteRequest.svelte
@@ -3,7 +3,7 @@
 	import CornerDownRight from "lucide-svelte/icons/corner-down-right";
 	import type { Station } from "$models/station";
 
-	let { stations }: { stations: Promise<{ from: Station; to: Station; }> } = $props();
+	let { stations }: { stations: Promise<{ from: Station; to: Station }> } = $props();
 </script>
 
 <div class="flex flex-col items-start gap-y-1">

--- a/frontend/src/components/route-planner/RouteRequest.svelte
+++ b/frontend/src/components/route-planner/RouteRequest.svelte
@@ -3,18 +3,12 @@
 	import CornerDownRight from "lucide-svelte/icons/corner-down-right";
 	import type { Station } from "$models/station";
 
-	let {
-		from,
-		to
-	}: {
-		from: Station | undefined;
-		to: Station | undefined;
-	} = $props();
+	let { stations }: { stations: Promise<{ from: Station; to: Station; }> } = $props();
 </script>
 
 <div class="flex flex-col items-start gap-y-1">
 	<span class="text-2xl font-bold">Route</span>
-	{#if !from && !to}
+	{#await stations}
 		<div class="flex flex-row items-center gap-x-2">
 			<CircleDot />
 			<span class="bg-primary-dark/40 h-[2rem] w-[12rem] animate-pulse rounded-2xl text-lg font-medium"></span>
@@ -24,7 +18,7 @@
 			<CornerDownRight />
 			<span class="bg-primary-dark/40 h-[2rem] w-[12rem] animate-pulse rounded-2xl text-lg font-medium"></span>
 		</div>
-	{:else}
+	{:then { from, to }}
 		<div class="flex flex-row items-center gap-x-2">
 			<CircleDot />
 			<span class="text-lg font-medium">{from?.name}</span>
@@ -34,5 +28,5 @@
 			<CornerDownRight />
 			<span class="text-lg font-medium">{to?.name}</span>
 		</div>
-	{/if}
+	{/await}
 </div>

--- a/frontend/src/components/ui/icons/SpinningCircle.svelte
+++ b/frontend/src/components/ui/icons/SpinningCircle.svelte
@@ -1,42 +1,46 @@
 <script lang="ts">
-	let { width = "75px", height = "75px" }: {
+	let {
+		width = "75px",
+		height = "75px"
+	}: {
 		width?: string;
 		height?: string;
 	} = $props();
 </script>
 
 <svg id="spinner" {height} {width} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
-	<circle class="cls-1" cx="512" cy="512" r="450"/>
-	<path class="cls-2" d="M687,512c0-96.65-78.35-175-175-175s-175,78.35-175,175"/>
+	<circle class="cls-1" cx="512" cy="512" r="450" />
+	<path class="cls-2" d="M687,512c0-96.65-78.35-175-175-175s-175,78.35-175,175" />
 </svg>
 
 <style>
-    .cls-1 {
-        stroke: var(--text);
-        stroke-width: 100px;
-    }
+	.cls-1 {
+		stroke: var(--text);
+		stroke-width: 100px;
+	}
 
-    .cls-1, .cls-2 {
-        fill: none;
-        stroke-miterlimit: 10;
-    }
+	.cls-1,
+	.cls-2 {
+		fill: none;
+		stroke-miterlimit: 10;
+	}
 
-    .cls-2 {
-        stroke: var(--accent);
+	.cls-2 {
+		stroke: var(--accent);
 		stroke-width: 125px;
-        stroke-linecap: round;
-        animation: spin 1.5s linear infinite;
+		stroke-linecap: round;
+		animation: spin 1.5s linear infinite;
 
 		transform-origin: center center;
-    }
+	}
 
-    @keyframes spin {
-        0% {
-            transform: rotate(0deg);
-        }
+	@keyframes spin {
+		0% {
+			transform: rotate(0deg);
+		}
 
-        100% {
-            transform: rotate(360deg);
-        }
-    }
+		100% {
+			transform: rotate(360deg);
+		}
+	}
 </style>

--- a/frontend/src/components/ui/icons/SpinningCircle.svelte
+++ b/frontend/src/components/ui/icons/SpinningCircle.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	let { width = "75px", height = "75px" }: {
+		width?: string;
+		height?: string;
+	} = $props();
+</script>
+
+<svg id="spinner" {height} {width} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+	<circle class="cls-1" cx="512" cy="512" r="450"/>
+	<path class="cls-2" d="M687,512c0-96.65-78.35-175-175-175s-175,78.35-175,175"/>
+</svg>
+
+<style>
+    .cls-1 {
+        stroke: var(--text);
+        stroke-width: 100px;
+    }
+
+    .cls-1, .cls-2 {
+        fill: none;
+        stroke-miterlimit: 10;
+    }
+
+    .cls-2 {
+        stroke: var(--accent);
+		stroke-width: 125px;
+        stroke-linecap: round;
+        animation: spin 1.5s linear infinite;
+
+		transform-origin: center center;
+    }
+
+    @keyframes spin {
+        0% {
+            transform: rotate(0deg);
+        }
+
+        100% {
+            transform: rotate(360deg);
+        }
+    }
+</style>

--- a/frontend/src/routes/(navbar-dropdown-disabled)/journey/planned/+page.server.ts
+++ b/frontend/src/routes/(navbar-dropdown-disabled)/journey/planned/+page.server.ts
@@ -1,0 +1,50 @@
+import type { PageServerLoad } from "./$types";
+import type { Station } from "$models/station";
+import type { RouteData } from "$models/route";
+import { error } from "@sveltejs/kit";
+import { env } from "$env/dynamic/private";
+
+export const load: PageServerLoad = async ({
+	url
+}): Promise<{
+	stations: Promise<{ from: Station; to: Station }>;
+	route: Promise<RouteData>;
+}> => {
+	const urlParams = new URLSearchParams(url.search);
+
+	const from = urlParams.get("from");
+	const to = urlParams.get("to");
+
+	if (!from || !to) throw error(400, "Missing required parameters");
+
+	return {
+		stations: Promise.all([loadStation(from), loadStation(to)]).then(([from, to]) => ({ from, to })),
+		route: loadRoute(from, to, urlParams)
+	};
+};
+
+const loadStation = async (evaNumber: string): Promise<Station> => {
+	const request = await fetch(`${env.BACKEND_DOCKER_BASE_URL}/api/v1/stations/${evaNumber}`, {
+		method: "GET"
+	});
+	if (!request.ok) throw error(400, "Failed to fetch station");
+	return (await request.json()) as Station;
+};
+
+const loadRoute = async (from: string, to: string, urlParams: URLSearchParams): Promise<RouteData> => {
+	const params = new URLSearchParams({
+		from,
+		to,
+		...(urlParams.has("departure") && { departure: urlParams.get("departure")! }),
+		...(urlParams.has("arrival") && { arrival: urlParams.get("arrival")! }),
+		...(urlParams.has("disabledProducts") && { disabledProducts: urlParams.get("disabledProducts")! }),
+		...(urlParams.has("results") && { results: urlParams.get("results")! }),
+		...(urlParams.has("earlierThan") && { earlierThan: urlParams.get("earlierThan")! }),
+		...(urlParams.has("laterThan") && { laterThan: urlParams.get("laterThan")! })
+	});
+	const request = await fetch(`${env.BACKEND_DOCKER_BASE_URL}/api/v1/journey/route-planner?${params.toString()}`, {
+		method: "GET"
+	});
+	if (!request.ok) throw error(400, "Failed to fetch route");
+	return (await request.json()) as RouteData;
+};

--- a/frontend/src/routes/(navbar-dropdown-disabled)/journey/planned/+page.svelte
+++ b/frontend/src/routes/(navbar-dropdown-disabled)/journey/planned/+page.svelte
@@ -16,10 +16,10 @@
 	let { data }: PageProps = $props();
 
 	let plannedStations = $state<{ from?: Station; to?: Station }>({ from: undefined, to: undefined });
-	data.stations.then((stations) => plannedStations = stations);
+	data.stations.then((stations) => (plannedStations = stations));
 
 	let plannedRoute = $state<RouteData | undefined>(undefined);
-	data.route.then((route) => plannedRoute = route);
+	data.route.then((route) => (plannedRoute = route));
 
 	let loadingEarlier = $state<boolean>(false);
 	let loadingLater = $state<boolean>(false);
@@ -95,7 +95,7 @@
 	}}
 />
 
-<div class="mx-auto flex min-h-full w-full flex-1 flex-col gap-y-4 px-2 my-4 md:max-w-[65%] md:px-0">
+<div class="mx-auto my-4 flex min-h-full w-full flex-1 flex-col gap-y-4 px-2 md:max-w-[65%] md:px-0">
 	<!-- Route Request Info -->
 	<RouteRequest stations={data?.stations} />
 

--- a/frontend/src/routes/(navbar-dropdown-disabled)/journey/planned/+page.svelte
+++ b/frontend/src/routes/(navbar-dropdown-disabled)/journey/planned/+page.svelte
@@ -133,7 +133,7 @@
 	}}
 />
 
-<div class="mx-auto flex min-h-full w-full flex-1 flex-col gap-y-4 px-2 md:max-w-[65%] md:px-0">
+<div class="mx-auto flex min-h-full w-full flex-1 flex-col gap-y-4 px-2 my-4 md:max-w-[65%] md:px-0">
 	<!-- Route Request Info -->
 	<RouteRequest from={stations.from} to={stations.to} />
 

--- a/frontend/src/routes/(root)/+layout.svelte
+++ b/frontend/src/routes/(root)/+layout.svelte
@@ -1,16 +1,12 @@
 <script lang="ts">
 	import Navbar from "$components/Navbar.svelte";
 	import type { LayoutProps } from "./$types";
-	import { setContext } from "svelte";
 	import { DateTime } from "luxon";
 	import GitHub from "$components/ui/icons/GitHub.svelte";
 	import { MetaTags } from "svelte-meta-tags";
 	import ServerCog from "lucide-svelte/icons/server-cog";
 
 	let { children }: LayoutProps = $props();
-	let currentType = $state("timetable");
-
-	setContext("currentType", () => currentType);
 </script>
 
 <MetaTags


### PR DESCRIPTION
This pull request aims to improve the route-planner and fixing a calculating bug in the backend. 

### Backend
* fixes [calculateDuration](https://github.com/schmolldechse/navigator/blob/31c191b0a0012c63a1d2317658171326965649b8/backend/src/lib/time.ts#L3) by setting duration fallback to -1 instead of throwing an error. There was an issue when looking up for connections/ routes which lead to 400 responses, as the calculation could not be calculated.

### Frontend
* refactored [+page.svelte](https://github.com/schmolldechse/navigator/blob/31c191b0a0012c63a1d2317658171326965649b8/frontend/src/routes/(navbar-dropdown-disabled)/journey/planned/%2Bpage.svelte) which add's the server-side load function back. This fetches station & route data by streaming it to the frontend and client-side logic is reduced.
* added [SpinningCircle.svelte](https://github.com/schmolldechse/navigator/blob/31c191b0a0012c63a1d2317658171326965649b8/frontend/src/components/ui/icons/SpinningCircle.svelte) for **Earlier connections** & **Later connections** buttons in RoutePlanner. This improves user experience, as the user knows the data is being loaded. 