### PR TITLE
feat: messages on stops

### DIFF
--- a/backend/src/lib/mapping.ts
+++ b/backend/src/lib/mapping.ts
@@ -72,10 +72,14 @@ const mapConnection = (
 
 		if (matchingDestination) {
 			connection.destination!.cancelled = matchingDestination?.cancelled ?? false;
+			connection.destination!.messages = matchingDestination?.messages ?? undefined;
+
 			connection.viaStops = connection?.viaStops?.filter((stop: Stop) => stop !== matchingDestination);
 		}
 		if (matchingOrigin) {
 			connection.origin!.cancelled = matchingOrigin?.cancelled ?? false;
+			connection.origin!.messages = matchingOrigin?.messages ?? undefined;
+
 			connection.viaStops = connection?.viaStops?.filter((stop: Stop) => stop !== matchingOrigin);
 		}
 	}

--- a/frontend/src/components/route-planner/Route.svelte
+++ b/frontend/src/components/route-planner/Route.svelte
@@ -65,19 +65,11 @@
 </script>
 
 <div class="border-primary/45 overflow-hidden rounded-lg border-2">
-	<!-- Cancelled Header -->
-	{#if isCancelled}
+	<!-- Header -->
+	{#if isCancelled || !isChangeoverPossible}
 		<div class="bg-secondary/50 flex flex-row items-center gap-x-2 px-3 py-1">
 			<Ban size="20" />
 			<span class="text-sm font-semibold md:text-lg">Route is not possible</span>
-		</div>
-	{/if}
-
-	<!-- Changeover Header -->
-	{#if !isChangeoverPossible}
-		<div class="bg-secondary/50 flex flex-row items-center gap-x-2 px-3 py-1">
-			<Ban size="20" />
-			<span class="text-sm font-semibold md:text-lg">Changeover is not possible</span>
 		</div>
 	{/if}
 

--- a/frontend/src/components/route-planner/details/StopChild.svelte
+++ b/frontend/src/components/route-planner/details/StopChild.svelte
@@ -76,7 +76,7 @@
 		</div>
 
 		<div class="flex flex-col">
-			{#each (stop?.messages ?? []) as message}
+			{#each stop?.messages ?? [] as message}
 				<div class="flex items-center gap-x-2">
 					<GeneralWarning />
 					<span class="text-sm font-semibold">{message?.text}</span>

--- a/frontend/src/components/route-planner/details/StopChild.svelte
+++ b/frontend/src/components/route-planner/details/StopChild.svelte
@@ -5,7 +5,7 @@
 	import CircleDot from "lucide-svelte/icons/circle-dot";
 	import ChevronRight from "lucide-svelte/icons/chevron-right";
 	import Platform from "$components/ui/info/Platform.svelte";
-	import CancelledTrip from "$components/timetable/messages/icons/CancelledTrip.svelte";
+	import GeneralWarning from "$components/timetable/messages/icons/GeneralWarning.svelte";
 
 	let {
 		time,
@@ -75,12 +75,14 @@
 			<ChevronRight color="#ffda0a" class="ml-1 shrink-0" />
 		</div>
 
-		{#if stop?.cancelled}
-			<div class="bg-text text-background flex w-full flex-row items-center gap-x-2 p-1">
-				<CancelledTrip />
-				<span class="text-sm font-semibold">Stop cancelled</span>
-			</div>
-		{/if}
+		<div class="flex flex-col">
+			{#each (stop?.messages ?? []) as message}
+				<div class="flex items-center gap-x-2">
+					<GeneralWarning />
+					<span class="text-sm font-semibold">{message?.text}</span>
+				</div>
+			{/each}
+		</div>
 	</div>
 
 	<!-- 1/6 Platform -->

--- a/frontend/src/routes/(root)/route-planner/+page.svelte
+++ b/frontend/src/routes/(root)/route-planner/+page.svelte
@@ -56,7 +56,7 @@
 			<StationSearch bind:station={start} placeholder="Start" class="z-0 md:text-xl" />
 
 			<button
-				class="bg-accent hover:bg-accent group absolute top-1/2 z-10 mr-4 -translate-y-1/2 cursor-pointer self-end rounded-full p-2"
+				class="bg-accent hover:bg-accent absolute top-1/2 z-10 mr-4 -translate-y-1/2 cursor-pointer self-end rounded-full p-2 transition-transform duration-300 hover:rotate-180"
 				onclick={() => {
 					if (!start || !destination) return;
 					if (start.evaNumber === destination.evaNumber) return;
@@ -66,7 +66,7 @@
 					destination = temp;
 				}}
 			>
-				<ArrowUpDown class="stroke-background stroke-3 transition-transform duration-300 hover:rotate-180" />
+				<ArrowUpDown class="stroke-background stroke-3" />
 			</button>
 
 			<StationSearch bind:station={destination} placeholder="Destination" class="z-0 md:text-xl" />


### PR DESCRIPTION
### Backend Changes:
* [mapping.ts](https://github.com/schmolldechse/navigator/blob/c32d8d900c940b57b0a984e879c6d4267a6529aa/backend/src/lib/mapping.ts#L11): added messages in origin & destination to the Connection. This ensures that the messages are available as well, as they were only available in viaStops before. Our goal is to exclude origin & destination from the viaStops.

### Frontend Changes:
* [Route.svelte](https://github.com/schmolldechse/navigator/blob/c32d8d900c940b57b0a984e879c6d4267a6529aa/frontend/src/components/route-planner/Route.svelte): combined headers for cancelled routes & impossible changeovers. This simplifies the UI and improves clarity for users, as they were the same message.
* [StopChild.svelte](https://github.com/schmolldechse/navigator/blob/c32d8d900c940b57b0a984e879c6d4267a6529aa/frontend/src/components/route-planner/details/StopChild.svelte): replaced `cancelled` indicator with general warnings. As the `Stop cancelled` message is included in the messages as well, this made no sense to separate.
* RoutePlanner [+page.svelte](https://github.com/schmolldechse/navigator/blob/c32d8d900c940b57b0a984e879c6d4267a6529aa/frontend/src/routes/(root)/route-planner/%2Bpage.svelte): fixed rotation animation, when the mouse hovers above the whole button